### PR TITLE
adjusted kfac to work with spin_state as input to the model

### DIFF
--- a/kfac_jax/_src/tag_graph_matcher.py
+++ b/kfac_jax/_src/tag_graph_matcher.py
@@ -324,9 +324,9 @@ def make_jax_graph(
     tag_ctor: Optional[TagCtor] = None,
 ) -> JaxprGraph:
   """Creates a :class:`~JaxGraph` instance from the provided function and arguments."""
-  # we always put spin_state as the third argument
-  func_args_without_spin_state = tuple([arg for idx, arg in enumerate(list(func_args)) if idx != 2])
-  in_tree = jax.tree_util.tree_structure(func_args_without_spin_state)
+  # we always put static_args as the third argument
+  func_args_without_static_args = tuple([arg for idx, arg in enumerate(list(func_args)) if idx != 2])
+  in_tree = jax.tree_util.tree_structure(func_args_without_static_args)
   closed_jaxpr, out_shapes = jax.make_jaxpr(func, return_shape=True, static_argnums=[2])(*func_args)
   # closed_jaxpr, out_shapes = jax.make_jaxpr(func, return_shape=True)(*func_args)
 
@@ -1267,9 +1267,9 @@ class TaggedFunction:
     self._param_labels = self._compute_parameter_labels()
 
   def __call__(self, *args, **kwargs):
-    # we always put spin state as the third argument
-    args_without_spin_state = tuple([arg for idx, arg in enumerate(list(args)) if idx != 2])
-    flat_args = jax.tree_util.tree_leaves(args_without_spin_state)
+    # we always put static_args as the third argument
+    args_without_static_args = tuple([arg for idx, arg in enumerate(list(args)) if idx != 2])
+    flat_args = jax.tree_util.tree_leaves(args_without_static_args)
     flat_output = self._flat_func(*flat_args)
     return jax.tree_util.tree_unflatten(self._func_graph.out_tree, flat_output)
 

--- a/kfac_jax/_src/tracer.py
+++ b/kfac_jax/_src/tracer.py
@@ -348,9 +348,6 @@ def cached_transformation(
     if not allow_no_losses and not processed_jaxpr.loss_tags:
       raise ValueError("No registered losses have been found during tracing.")
 
-    # TODO: Fix this temporary fix
-    """This is commented out because when using pretraining on multiple geometries
-       it throws an error during optimization """
     if cache and raise_error_on_diff_jaxpr:
       # If any previous `ProcessedJaxpr` exists verify that they are equivalent
       ref_jaxpr, _ = cache[next(iter(cache))]

--- a/kfac_jax/_src/tracer.py
+++ b/kfac_jax/_src/tracer.py
@@ -57,7 +57,10 @@ JaxprOrClosedJaxpr = Union[jax.core.Jaxpr, jax.core.ClosedJaxpr]
 
 def shape_and_type(x: chex.Array) -> Tuple[chex.Shape, chex.ArrayDType]:
   """Returns the shape and type of the given array."""
-  return x.shape, x.dtype
+  if type(x) == int:
+    return (), int
+  else:
+    return x.shape, x.dtype
 
 
 def make_cache_key(
@@ -345,6 +348,9 @@ def cached_transformation(
     if not allow_no_losses and not processed_jaxpr.loss_tags:
       raise ValueError("No registered losses have been found during tracing.")
 
+    # TODO: Fix this temporary fix
+    """This is commented out because when using pretraining on multiple geometries
+       it throws an error during optimization """
     if cache and raise_error_on_diff_jaxpr:
       # If any previous `ProcessedJaxpr` exists verify that they are equivalent
       ref_jaxpr, _ = cache[next(iter(cache))]


### PR DESCRIPTION
Made changes to have spin_state as input to the model, which is passed under "additional_args" to kfac optimizer. This additional args is kept as a static argument throughout the function calls, such that it is passed as integers to the model function and not as some jax data type.